### PR TITLE
fix: skip UI copy when index.html is symlinked

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -119,8 +119,12 @@ sudo -u $USER mkdir -p "$KF_DATA_DIR/ui"
 log_info "Deploying UI files..."
 echo "Deploying UI from ${SRCDIR}/ui to $KF_DATA_DIR/ui/" >> "$LOG_FILE"
 if [ -d "${SRCDIR}/ui" ]; then
-    sudo -u $USER cp -r "${SRCDIR}/ui/"* "$KF_DATA_DIR/ui/"
-    echo "UI deployment command executed." >> "$LOG_FILE"
+    if [ -L "$KF_DATA_DIR/ui/index.html" ]; then
+        echo "UI is symlinked; skipping copy." >> "$LOG_FILE"
+    else
+        sudo -u $USER cp -r "${SRCDIR}/ui/"* "$KF_DATA_DIR/ui/"
+        echo "UI deployment command executed." >> "$LOG_FILE"
+    fi
 else
     echo "UI directory not found in SRCDIR!" >> "$LOG_FILE"
     log_warn "UI directory not found at ${SRCDIR}/ui (continuing)."


### PR DESCRIPTION
## Summary

- When `$KF_DATA_DIR/ui/index.html` is a symlink back to the source tree, `cp -r` crashes with `"are the same file"`
- Since `git pull` already updated the source, the symlinked destination is already current — no copy needed
- Wraps the `cp` in a `[ -L ... ]` check: symlink → skip, regular file → copy as before

## Live test evidence (v24)

```
$ cat /tmp/klipperfleet-install.log
--- Install started at Wed 18 Mar 09:21:53 CET 2026 ---
EUID: 0
USER: pi
USER_HOME: /home/pi
Deploying UI from /home/pi/KlipperFleet/ui to /home/pi/printer_data/config/klipperfleet/ui/
UI is symlinked; skipping copy.
```

`install.sh` completed with exit code 0 on v24 with a symlinked `index.html`. Previously this would fail with `cp: '…/index.html' and '…/index.html' are the same file`.

## Test plan

- [x] Symlink present → install completes, log shows "UI is symlinked; skipping copy."
- [x] Regular file (fresh install) → `cp -r` runs as before
- [x] Full `install.sh` run on v24 with symlink → exit code 0