### PR TITLE
fix(ui): preserve port and title in return link

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -652,17 +652,10 @@ async def get_print_status() -> Dict[str, Any]:
     return await flash_mgr.check_printer_printing()
 
 @app.get("/api/printer-ui")
-async def get_printer_ui(request: Request) -> Dict[str, str]:
-    """Returns the detected printer UI name by server-side fetch of manifest from referrer URL."""
-    # Extract port from referrer header
-    referrer = request.headers.get("referer", "")
-    port = 80
-    if referrer:
-        try:
-            parsed = urlparse(referrer)
-            port = parsed.port or 80
-        except Exception:
-            pass
+async def get_printer_ui(port: int = 80) -> Dict[str, str]:
+    """Returns the detected printer UI name by server-side fetch of manifest from localhost."""
+    if not (1 <= port <= 65535):
+        return {"uiName": "Printer UI"}
 
     # Try fetching manifest files from the referrer's port
     for manifest_path in ["/manifest.webmanifest", "/manifest.json"]:

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,7 @@ from fastapi.responses import StreamingResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from typing import List, Dict, Any, Optional, AsyncGenerator
+from urllib.parse import urlparse
 import os
 import asyncio
 import json
@@ -649,6 +650,33 @@ async def get_health() -> Dict[str, Any]:
 async def get_print_status() -> Dict[str, Any]:
     """Returns whether any printer is currently printing (via Moonraker)."""
     return await flash_mgr.check_printer_printing()
+
+@app.get("/api/printer-ui")
+async def get_printer_ui(request: Request) -> Dict[str, str]:
+    """Returns the detected printer UI name by server-side fetch of manifest from referrer URL."""
+    # Extract port from referrer header
+    referrer = request.headers.get("referer", "")
+    port = 80
+    if referrer:
+        try:
+            parsed = urlparse(referrer)
+            port = parsed.port or 80
+        except Exception:
+            pass
+
+    # Try fetching manifest files from the referrer's port
+    for manifest_path in ["/manifest.webmanifest", "/manifest.json"]:
+        try:
+            async with httpx.AsyncClient(timeout=2.0) as client:
+                response = await client.get(f"http://localhost:{port}{manifest_path}")
+                if response.status_code == 200:
+                    manifest = response.json()
+                    ui_name = manifest.get("name", "").lower()
+                    if ui_name in ["mainsail", "fluidd", "octoprint"]:
+                        return {"uiName": ui_name.capitalize()}
+        except Exception:
+            pass
+    return {"uiName": "Printer UI"}
 
 
 @app.get('/klipper/version')

--- a/ui/index.html
+++ b/ui/index.html
@@ -1861,7 +1861,7 @@
                             printerUrl.value = document.referrer;
                             hasReferrer.value = true;
                             // Fetch printer UI name from KlipperFleet API (no CORS issues)
-                            fetch('/api/printer-ui')
+                            fetch('/api/printer-ui?port=' + (referrerUrl.port || '80'))
                                 .then(r => r.json())
                                 .then(data => {
                                     if (data.uiName) {

--- a/ui/index.html
+++ b/ui/index.html
@@ -83,8 +83,8 @@
                     <button @click="sidebarOpen = !sidebarOpen" class="md:hidden text-gray-400 hover:text-white p-1">
                         <i class="fas fa-bars text-lg"></i>
                     </button>
-                    <a :href="mainsailUrl" class="hidden md:flex text-gray-400 hover:text-white items-center text-sm transition-colors mr-4 border-r border-gray-800 pr-4">
-                        <i class="fas fa-arrow-left mr-2"></i> Return to Mainsail
+                    <a v-if="hasReferrer" :href="printerUrl" class="hidden md:flex text-gray-400 hover:text-white items-center text-sm transition-colors mr-4 border-r border-gray-800 pr-4">
+                        <i class="fas fa-arrow-left mr-2"></i> Return to {{ printerTitle }}
                     </a>
                     <h2 class="text-lg md:text-xl font-semibold capitalize">{{ view }}</h2>
                     <span v-if="building || flashing" class="flex items-center text-orange-400 text-xs md:text-sm ml-auto md:ml-0">
@@ -849,7 +849,9 @@
                 const expandLogs = ref(localStorage.getItem('kf_expand_logs') === 'true');
                 const expandLogsHeight = ref(localStorage.getItem('kf_expand_logs_height') || '800px');
                 const error = ref(null);
-                const mainsailUrl = window.location.protocol + '//' + window.location.hostname;
+                const printerUrl = ref('');
+                const printerTitle = ref('Printer');
+                const hasReferrer = ref(false);
                 const showRawSymbolNames = ref(localStorage.getItem('kf_show_raw_symbols') === 'true');
                 const showOptionalFeatures = ref(localStorage.getItem('kf_show_optional') === 'true');
                 const isKlipperKconfiglib = ref(true);
@@ -1852,6 +1854,29 @@
                 };
 
                 onMounted(() => {
+                    // Resolve return-link from document.referrer (client-side only)
+                    if (document.referrer) {
+                        try {
+                            const referrerUrl = new URL(document.referrer);
+                            printerUrl.value = document.referrer;
+                            hasReferrer.value = true;
+                            // Fetch printer UI name from KlipperFleet API (no CORS issues)
+                            fetch('/api/printer-ui')
+                                .then(r => r.json())
+                                .then(data => {
+                                    if (data.uiName) {
+                                        printerTitle.value = data.uiName;
+                                    }
+                                })
+                                .catch(() => {
+                                    // Fallback to default if API call fails
+                                });
+                        } catch {
+                            // Invalid referrer URL — hide link
+                            hasReferrer.value = false;
+                        }
+                    }
+
                     fetchProfiles().then(() => {
                         if (selectedProfile.value && !profiles.value.includes(selectedProfile.value)) {
                             selectedProfile.value = '';
@@ -1932,7 +1957,7 @@
                     buildLogs, formattedLogs, expandLogs, expandLogsHeight, updateValue, saveProfile, saveProfileAs, newProfile, deleteProfile, renameProfile, loadProfile, createMissingProfile, startBuild, runBatch, selfUpdate,
                     devices, selectedDevice, discoverDevices, startFlash, quickFlash, quickBuild, quickFlashOnly, flashBeacon, beaconUpToDate, buildAndDownload, rebootDevice, statusColor, formatStatus,
                     addDeviceToFleet, attachToFleet, updateFleetDevice, onDeviceProfileChange, removeDeviceFromFleet, error, modifiedValues, formatNotes,
-                    mainsailUrl, profileInfo, isProfileCanBridge, isProfileLinux,
+                    printerUrl, printerTitle, hasReferrer, profileInfo, isProfileCanBridge, isProfileLinux,
                     modal, showAlert, showConfirm, showPrompt, closeModal, testMagicBaud,
                     services, manageServices, cancelTask, currentTaskId,
                     showRawSymbolNames, showOptionalFeatures, isKlipperKconfiglib, firmwareName,


### PR DESCRIPTION
## Summary
- Fixes port issue where "Return to Mainsail" link always goes to port 80 instead of preserving current port (Fluidd on 81)
- Renames link text from "Return to Mainsail" to "Return to Printer UI" for neutrality

## Testing
- Manual verification on Fluidd (port 81) confirms link now returns to port 81