### PR TITLE
fix: Flash Ready flashes direct-flash & DFU MCUs; rework flash state model (#25), UI Update.

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,7 @@ from fastapi import FastAPI, HTTPException, BackgroundTasks, Request
 from fastapi.responses import StreamingResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
-from typing import List, Dict, Any, Optional, AsyncGenerator
+from typing import List, Dict, Any, Optional, AsyncGenerator, Tuple
 from urllib.parse import urlparse
 import os
 import asyncio
@@ -390,14 +390,141 @@ def resolve_firmware_path(profile_name: str, method: str) -> Optional[str]:
     return None
 
 
-def is_avr_profile(profile_name: str) -> bool:
-    """Check if a profile targets an AVR microcontroller."""
+def _read_profile_config(profile_name: str) -> Optional[str]:
+    """Returns the raw .config content for a profile, or None if unavailable."""
     config_path = os.path.join(PROFILES_DIR, f'{profile_name}.config')
     try:
         with open(config_path, 'r') as f:
-            return 'CONFIG_MACH_AVR=y' in f.read()
+            return f.read()
     except Exception:
+        return None
+
+
+def is_avr_profile(profile_name: str) -> bool:
+    """Check if a profile targets an AVR microcontroller."""
+    content = _read_profile_config(profile_name)
+    return content is not None and 'CONFIG_MACH_AVR=y' in content
+
+
+# MCU architectures that have no Katapult/serial bootloader and are written in
+# place with `make flash` (avrdude, bossac, ...). These never enter a "ready"
+# bootloader state, so for them "service" IS the flashable state.
+_DIRECT_FLASH_MARKERS = ('CONFIG_MACH_AVR=y', 'CONFIG_MACH_SAM=y')
+
+
+def _is_direct_flash_profile(profile_name: str) -> bool:
+    """Check if a profile targets an MCU that flashes directly (no bootloader)."""
+    content = _read_profile_config(profile_name)
+    if content is None:
         return False
+    return any(marker in content for marker in _DIRECT_FLASH_MARKERS)
+
+
+def resolve_flash_protocol(device: Dict[str, Any]) -> str:
+    """The fixed way a device receives firmware: 'linux', 'dfu', 'direct', or
+    'katapult'.
+
+    This is the *static* half of a device's state — it answers *how* to flash,
+    derived from the device's method and profile. It never says *whether* the
+    device is ready right now; that is is_flashable_now()'s job. Keeping the two
+    apart is what stops "service" from meaning different things per board type.
+    """
+    method = device.get('method')
+    if method == 'linux':
+        return 'linux'
+    if method == 'beacon':
+        return 'beacon'
+    if method == 'dfu':
+        return 'dfu'
+    if method == 'serial':
+        # Bridges always reach Katapult over their serial endpoint.
+        if device.get('is_bridge'):
+            return 'katapult'
+        # An explicit fleet flag is authoritative.
+        if device.get('is_katapult') is False:
+            return 'direct'
+        # Otherwise infer direct-flash MCUs (AVR, SAM) from the profile so older
+        # fleet entries that predate the is_katapult flag still classify right.
+        profile = device.get('profile')
+        if profile and _is_direct_flash_profile(profile):
+            return 'direct'
+        return 'katapult'
+    # CAN (and anything unexpected) goes through Katapult.
+    return 'katapult'
+
+
+def flashes_directly(device: Dict[str, Any]) -> bool:
+    """True when the device is written in place via `make flash` — no bootloader
+    reboot exists, so it flashes while still in 'service'."""
+    return resolve_flash_protocol(device) == 'direct'
+
+
+def is_flashable_now(status: str, device: Dict[str, Any]) -> bool:
+    """Whether firmware can be written to the device right now, given its live
+    mode.
+
+    A device is flashable when it is already sitting in a bootloader
+    ('ready'/'dfu'), or when it is a direct-flash board still in 'service' —
+    because for those boards 'service' is their flashable state (no bootloader
+    to reboot into). This is the single readiness gate for "Flash Ready".
+    """
+    if status in ('ready', 'dfu'):
+        return True
+    if status == 'service' and flashes_directly(device):
+        return True
+    return False
+
+
+def reboots_into_bootloader(action: str, device: Dict[str, Any]) -> bool:
+    """Whether a batch run will reboot this (non-bridge) device into a bootloader
+    before flashing.
+
+    Only "Flash All" reboots running MCUs; "Flash Ready" leaves them alone and
+    flashes only what is already in a flashable state. Direct-flash boards
+    (AVR/SAM) flash in place and never need a reboot."""
+    return (
+        'flash-all' in action
+        and not device.get('is_bridge')
+        and device['method'] in ('can', 'serial', 'dfu')
+        and not flashes_directly(device)
+    )
+
+
+def flashed_by_ready(status: str, device: Dict[str, Any]) -> bool:
+    """Whether "Flash Ready" will flash this device, judged from its current
+    (services-running) status.
+
+    Used to skip building firmware that won't be flashed. The Linux host MCU
+    always flashes (it becomes 'ready' once services stop); every other device
+    must already be in a flashable state (Flash Ready never reboots)."""
+    if device.get('method') == 'linux':
+        return True
+    return is_flashable_now(status, device)
+
+
+def reconcile_flash_status(rechecked: str, original: Optional[str]) -> str:
+    """Reconcile a post-service-stop re-check against the discovery status.
+
+    A device present at discovery doesn't vanish when we stop services to flash.
+    A running Klipper-mode CAN/serial MCU that wasn't rebooted into Katapult
+    becomes undetectable once Moonraker is down and re-checks as 'offline'. In
+    that case trust the discovery status so decisions and the summary reflect
+    the device's real state."""
+    if rechecked == 'offline' and original and original != 'offline':
+        return original
+    return rechecked
+
+
+def skip_reason(status: str, device: Dict[str, Any]) -> str:
+    """Human-readable reason a device was skipped during a batch flash, for the
+    summary. Mirrors is_flashable_now(): the only legitimate skips are offline
+    devices and Katapult devices still running Klipper that would need a reboot
+    into the bootloader first (i.e. Flash All's job)."""
+    if status == 'offline':
+        return 'offline / unreachable'
+    if status == 'service' and not flashes_directly(device):
+        return 'needs reboot — use Flash All'
+    return status
 
 
 def get_flash_offset(profile_name: str) -> str:
@@ -1058,6 +1185,8 @@ async def batch_operation(
         flash_results: Dict[
             str, str
         ] = {}  # device_name -> "SUCCESS"/"SKIPPED"/"FAILED"
+        # device_name -> (flash protocol, live status) for the summary table
+        flash_meta: Dict[str, Tuple[str, str]] = {}
 
         try:
             devices: List[Dict[str, Any]] = await fleet_mgr.get_fleet()
@@ -1075,11 +1204,55 @@ async def batch_operation(
                     if d.get('profile'):
                         key = (d['profile'], d.get('custom_make_command') or None)
                         builds_needed[key] = key[1]
+                had_profiles = bool(builds_needed)
+
+                # For "Flash Ready", only build profiles whose devices will
+                # actually be flashed. No point compiling firmware for Katapult
+                # MCUs in service, offline devices, or excluded ones — Flash
+                # Ready won't flash them without a reboot (that's Flash All).
+                # Services are still running here, so status checks are accurate.
+                if 'flash-ready' in action and builds_needed:
+                    ready_keys = set()
+                    for d in devices:
+                        if not d.get('profile') or d.get('exclude_from_batch'):
+                            continue
+                        if d.get('method') == 'linux':
+                            will_flash = True
+                        else:
+                            st = await flash_mgr.check_device_status(
+                                d['id'],
+                                d['method'],
+                                dfu_id=d.get('dfu_id'),
+                                is_bridge=d.get('is_bridge', False),
+                                interface=d.get('interface', 'can0'),
+                                serial_id=d.get('serial_id'),
+                            )
+                            will_flash = flashed_by_ready(st, d)
+                        if will_flash:
+                            ready_keys.add(
+                                (
+                                    d['profile'],
+                                    d.get('custom_make_command') or None,
+                                )
+                            )
+                    for key in list(builds_needed):
+                        if key not in ready_keys:
+                            task_store.add_log(
+                                task_id,
+                                f'>>> Skipping build for {key[0]} — not ready '
+                                f'to flash (use Flash All).\n',
+                            )
+                            del builds_needed[key]
+
                 if not builds_needed:
-                    task_store.add_log(
-                        task_id,
-                        '>>> No profiles assigned to fleet devices. Skipping build.\n',
+                    msg = (
+                        '>>> No ready devices to flash — nothing to build. '
+                        'Use Flash All to build and flash everything.\n'
+                        if had_profiles
+                        else '>>> No profiles assigned to fleet devices. '
+                        'Skipping build.\n'
                     )
+                    task_store.add_log(task_id, msg)
                 else:
                     for (profile, custom_cmd), _ in builds_needed.items():
                         if task_store.is_cancelled(task_id):
@@ -1141,17 +1314,25 @@ async def batch_operation(
                     )
                     for excl_dev in excluded_devices:
                         flash_results[excl_dev['name']] = 'EXCLUDED'
+                        flash_meta[excl_dev['name']] = (
+                            resolve_flash_protocol(excl_dev),
+                            '—',
+                        )
 
                 task_store.add_log(
                     task_id,
                     '>>> Checking device statuses before stopping services...\n',
                 )
 
-                # Auto-detect AVR profiles and override is_katapult for devices that target AVR MCUs.
-                # This ensures AVR devices (e.g. ATmega2560) are never sent through the Katapult path,
-                # even if the user hasn't explicitly set is_katapult: false in the fleet.
+                # Normalize direct-flash profiles (AVR, SAM) so they are never sent
+                # through the Katapult path, even if the user hasn't explicitly set
+                # is_katapult: false in the fleet. resolve_flash_protocol() infers the
+                # same thing from the profile, but stamping the flag keeps any direct
+                # is_katapult reads consistent too.
                 for dev in devices:
-                    if dev.get('profile') and is_avr_profile(dev['profile']):
+                    if dev.get('profile') and _is_direct_flash_profile(
+                        dev['profile']
+                    ):
                         dev['is_katapult'] = False
 
                 # Issue #16: Auto-correct method for USB-to-CAN bridges whose device_id
@@ -1211,16 +1392,13 @@ async def batch_operation(
 
                     if status == 'service':
                         # Reboot non-bridge devices that need bootloader entry.
-                        # Skip serial devices without Katapult (e.g. AVR boards) — they flash directly.
-                        # Bridges are handled in the second phase to avoid killing the CAN bus prematurely.
-                        needs_reboot = (
-                            not dev.get('is_bridge')
-                            and dev['method'] in ('can', 'serial', 'dfu')
-                            and not (
-                                dev['method'] == 'serial'
-                                and not dev.get('is_katapult', True)
-                            )
-                        )
+                        # Only "Flash All" reboots running MCUs into a bootloader;
+                        # "Flash Ready" leaves them alone and flashes only what is
+                        # already in a flashable state. Direct-flash devices
+                        # (AVR/SAM) flash in place and never need a reboot. Bridges
+                        # are handled in the second phase to avoid killing the CAN
+                        # bus prematurely.
+                        needs_reboot = reboots_into_bootloader(action, dev)
                         if needs_reboot:
                             reboot_tasks.append(
                                 {
@@ -1451,13 +1629,28 @@ async def batch_operation(
                         interface=dev.get('interface', 'can0'),
                         serial_id=dev.get('serial_id'),
                     )
+
+                    # Don't let a running MCU that's merely undetectable with
+                    # services stopped (e.g. an un-rebooted Klipper CAN node
+                    # under Flash Ready) be mistaken for offline.
+                    status = reconcile_flash_status(
+                        status,
+                        device_statuses.get(dev.get('fleet_id', dev['id'])),
+                    )
+
                     task_store.update_device_status(task_id, dev['id'], status)
+
+                    # Record protocol + live status for the summary table.
+                    flash_meta[dev['name']] = (
+                        resolve_flash_protocol(dev),
+                        status,
+                    )
 
                     should_flash = False
                     if 'flash-all' in action:
                         should_flash = True
-                    elif 'flash-ready' in action and status == 'ready':
-                        should_flash = True
+                    elif 'flash-ready' in action:
+                        should_flash = is_flashable_now(status, dev)
 
                     if should_flash:
                         # CAN bridge already in Katapult serial mode: switch to serial flash
@@ -1603,20 +1796,19 @@ async def batch_operation(
                                     )
                                     continue
 
-                        # Non-Katapult serial devices (e.g. AVR) flash directly without bootloader
-                        is_direct_serial = dev[
-                            'method'
-                        ] == 'serial' and not dev.get('is_katapult', True)
+                        # Direct-flash devices (e.g. AVR/SAM) flash in place without a bootloader
+                        is_direct_serial = flashes_directly(dev)
                         if (
                             status not in ['ready', 'dfu']
                             and dev['method'] != 'linux'
                             and not is_direct_serial
                         ):
+                            reason = skip_reason(status, dev)
                             task_store.add_log(
                                 task_id,
-                                f'!!! Skipping {dev["name"]} ({dev["id"]}) - Device is {status}, not ready for flashing.\n',
+                                f'!!! Skipping {dev["name"]} ({dev["id"]}) - {reason}.\n',
                             )
-                            flash_results[dev['name']] = f'SKIPPED ({status})'
+                            flash_results[dev['name']] = f'SKIPPED ({reason})'
                             continue
 
                         task_store.add_log(
@@ -1640,10 +1832,8 @@ async def batch_operation(
                         )
                         batch_flash_ok = False
                         try:
-                            if dev['method'] == 'serial' and not dev.get(
-                                'is_katapult', True
-                            ):
-                                # Non-Katapult serial device — flash via make flash (handles AVR, RP2040, etc.)
+                            if flashes_directly(dev):
+                                # Direct-flash device — flash via make flash (handles AVR, SAM, etc.)
                                 config_path: str = os.path.join(
                                     PROFILES_DIR, f'{dev["profile"]}.config'
                                 )
@@ -1784,11 +1974,12 @@ async def batch_operation(
                             )
                             flash_results[dev['name']] = 'FAILED'
                     else:
+                        reason = skip_reason(status, dev)
                         task_store.add_log(
                             task_id,
-                            f'>>> Skipping {dev["name"]} (Status: {status})\n',
+                            f'>>> Skipping {dev["name"]} ({reason})\n',
                         )
-                        flash_results[dev['name']] = 'SKIPPED'
+                        flash_results[dev['name']] = f'SKIPPED ({reason})'
 
                 task_store.add_log(task_id, '\n>>> BATCH FLASH COMPLETED <<<\n')
 
@@ -1814,25 +2005,51 @@ async def batch_operation(
                             f'  [COLOR:RED]  - {profile}: {result}[/COLOR]\n',
                         )
 
-            # Flash summary
+            # Flash summary — columnar: device, [protocol, status], result, reason.
+            # protocol = how the board flashes (direct/katapult/dfu/linux);
+            # status = its live mode when the flash ran (ready/service/dfu/offline).
             if flash_results:
                 task_store.add_log(task_id, '\n  FLASH RESULTS:\n')
-                for device_name, result in flash_results.items():
-                    if result == 'SUCCESS':
-                        task_store.add_log(
-                            task_id,
-                            f'  [COLOR:GREEN]  - {device_name}: {result}[/COLOR]\n',
-                        )
-                    elif result.startswith('SKIPPED') or result == 'EXCLUDED':
-                        task_store.add_log(
-                            task_id,
-                            f'  [COLOR:YELLOW]  - {device_name}: {result}[/COLOR]\n',
-                        )
+
+                def _meta_str(name: str) -> str:
+                    proto, st = flash_meta.get(name, ('—', '—'))
+                    return f'[{proto}, {st}]'
+
+                def _split_result(result: str) -> Tuple[str, str]:
+                    # "SKIPPED (reason)" / "FAILED (reason)" -> ("SKIPPED", "reason")
+                    if result.endswith(')') and '(' in result:
+                        i = result.index('(')
+                        return result[:i].strip(), result[i + 1:-1]
+                    if result == 'EXCLUDED':
+                        return 'EXCLUDED', 'excluded from batch'
+                    return result, ''
+
+                rows = [
+                    (n, _meta_str(n)) + _split_result(r)
+                    for n, r in flash_results.items()
+                ]
+                name_w = max([len(r[0]) for r in rows] + [len('DEVICE')])
+                meta_w = max(
+                    [len(r[1]) for r in rows] + [len('[PROTOCOL, STATUS]')]
+                )
+                res_w = max([len(r[2]) for r in rows] + [len('RESULT')])
+                task_store.add_log(
+                    task_id,
+                    f'      {"DEVICE":<{name_w}}   {"[PROTOCOL, STATUS]":<{meta_w}}'
+                    f'   {"RESULT":<{res_w}}   SKIP REASON\n',
+                )
+                for name, meta, res_word, reason in rows:
+                    line = (
+                        f'  - {name:<{name_w}}   {meta:<{meta_w}}   '
+                        f'{res_word:<{res_w}}   {reason}'
+                    ).rstrip()
+                    if res_word == 'SUCCESS':
+                        color = 'GREEN'
+                    elif res_word in ('SKIPPED', 'EXCLUDED'):
+                        color = 'YELLOW'
                     else:
-                        task_store.add_log(
-                            task_id,
-                            f'  [COLOR:RED]  - {device_name}: {result}[/COLOR]\n',
-                        )
+                        color = 'RED'
+                    task_store.add_log(task_id, f'  [COLOR:{color}]{line}[/COLOR]\n')
 
             task_store.add_log(
                 task_id,
@@ -2273,8 +2490,19 @@ async def flash_device(req: FlashRequest) -> StreamingResponse:
                     exc_info=True,
                 )
 
-            # Auto-detect AVR from profile — override is_katapult if profile targets AVR
-            if is_avr_profile(req.profile):
+            # Resolve how this device flashes (static protocol) once, from the
+            # same logic the batch path uses. 'direct' devices (AVR/SAM) flash in
+            # place with `make flash` and never reboot into a bootloader.
+            flash_protocol = resolve_flash_protocol(
+                {
+                    'method': req.method,
+                    'profile': req.profile,
+                    'is_katapult': is_katapult,
+                    'is_bridge': is_bridge,
+                }
+            )
+            flashes_direct = flash_protocol == 'direct'
+            if flashes_direct:
                 is_katapult = False
 
             # Snapshot current serial devices BEFORE reboot (for diff-based detection)
@@ -2338,10 +2566,10 @@ async def flash_device(req: FlashRequest) -> StreamingResponse:
                         if not found:
                             yield '!!! TIMEOUT: DFU device not found. Aborting flash.\n'
                             return
-                elif req.method == 'serial' and not is_katapult:
-                    # Non-Katapult serial device (e.g. AVR/ATmega) — no reboot needed.
-                    # Services are already stopped; avrdude will flash directly.
-                    yield f'>>> Serial device (no Katapult): Skipping bootloader reboot for {req.device_id}.\n'
+                elif flashes_direct:
+                    # Direct-flash device (e.g. AVR/SAM) — no reboot needed.
+                    # Services are already stopped; it will flash in place.
+                    yield f'>>> Direct-flash device: Skipping bootloader reboot for {req.device_id}.\n'
                 else:
                     yield f'>>> Rebooting {req.device_id} to Katapult mode...\n'
                     async for log in flash_mgr.reboot_to_katapult(
@@ -2351,17 +2579,13 @@ async def flash_device(req: FlashRequest) -> StreamingResponse:
                             return
                         yield log
 
-                if req.method != 'linux' and not (
-                    req.method == 'serial' and not is_katapult
-                ):
+                if req.method != 'linux' and not flashes_direct:
                     yield '>>> Waiting for device to enter bootloader mode...\n'
                     await asyncio.sleep(2)  # Initial wait for USB bus to settle
 
                 # Active wait for bootloader (up to 30s) - check both DFU and new serial devices
-                # (Skip entirely for Linux MCU and non-Katapult serial devices - no bootloader transition needed)
-                skip_bootloader_wait = req.method == 'linux' or (
-                    req.method == 'serial' and not is_katapult
-                )
+                # (Skip entirely for Linux MCU and direct-flash devices - no bootloader transition needed)
+                skip_bootloader_wait = req.method == 'linux' or flashes_direct
                 for _ in range(30) if not skip_bootloader_wait else []:
                     if task_store.is_cancelled(task_id):
                         return
@@ -2492,8 +2716,8 @@ async def flash_device(req: FlashRequest) -> StreamingResponse:
             task_store.update_device_status(task_id, req.device_id, 'flashing')
             flash_succeeded = False
             try:
-                if actual_method == 'serial' and not is_katapult:
-                    # Non-Katapult serial device — flash via make flash (handles AVR, RP2040, etc.)
+                if actual_method == 'serial' and flashes_direct:
+                    # Direct-flash device — flash via make flash (handles AVR, SAM, etc.)
                     config_path: str = os.path.join(
                         PROFILES_DIR, f'{req.profile}.config'
                     )

--- a/backend/main.py
+++ b/backend/main.py
@@ -49,7 +49,7 @@ async def lifespan(application: FastAPI):
 
 
 app = FastAPI(
-    title='KlipperFleet API', version='1.3.2-alpha', lifespan=lifespan
+    title='KlipperFleet API', version='1.4.0-alpha', lifespan=lifespan
 )
 
 # Configuration

--- a/tests/test_backend_regression.py
+++ b/tests/test_backend_regression.py
@@ -674,48 +674,39 @@ class TestMakeFlash:
         assert "Error copying profile config" in combined
 
     def test_batch_reboot_skips_non_katapult_serial(self):
-        """In batch flash, serial devices without Katapult should NOT be added to reboot_tasks."""
-        # Simulates the reboot_tasks logic from main.py batch flash
-        devices = [
-            {"id": "avr-device", "method": "serial", "name": "AVR Board", "is_katapult": False, "is_bridge": False},
-            {"id": "stm-device", "method": "serial", "name": "STM Board", "is_katapult": True, "is_bridge": False},
-            {"id": "can-device", "method": "can", "name": "CAN Board", "is_bridge": False},
-        ]
+        """In batch flash, direct-flash serial devices should NOT need a reboot."""
+        from backend.main import flashes_directly
 
-        reboot_tasks = []
-        for dev in devices:
-            needs_reboot = (
+        # The batch reboot guard reboots non-bridge can/serial/dfu devices that
+        # are not direct-flash. Exercise it against the real flashes_directly().
+        def needs_reboot(dev):
+            return (
                 not dev.get('is_bridge')
                 and dev['method'] in ('can', 'serial', 'dfu')
-                and not (dev['method'] == 'serial' and not dev.get('is_katapult', True))
+                and not flashes_directly(dev)
             )
-            if needs_reboot:
-                reboot_tasks.append(dev['id'])
 
-        # AVR device should NOT be rebooted
-        assert "avr-device" not in reboot_tasks
-        # STM (Katapult) device should be rebooted
-        assert "stm-device" in reboot_tasks
-        # CAN device should be rebooted
-        assert "can-device" in reboot_tasks
+        avr = {"id": "avr", "method": "serial", "is_katapult": False, "is_bridge": False}
+        stm = {"id": "stm", "method": "serial", "is_katapult": True, "is_bridge": False}
+        can = {"id": "can", "method": "can", "is_bridge": False}
+
+        assert not needs_reboot(avr)   # direct-flash → flashes in place
+        assert needs_reboot(stm)       # Katapult serial → reboot to bootloader
+        assert needs_reboot(can)       # CAN → reboot to Katapult
 
     def test_batch_status_allows_direct_serial_flash(self):
-        """Non-Katapult serial devices should NOT be skipped when status is 'service'."""
-        # Simulates the status guard from main.py batch flash
+        """is_flashable_now: direct-serial in 'service' is flashable; Katapult is not."""
+        from backend.main import is_flashable_now
+
         dev_katapult = {"method": "serial", "is_katapult": True}
         dev_avr = {"method": "serial", "is_katapult": False}
-        dev_linux = {"method": "linux"}
 
-        def should_skip(dev, status):
-            is_direct_serial = dev['method'] == 'serial' and not dev.get('is_katapult', True)
-            return status not in ["ready", "dfu"] and dev['method'] != "linux" and not is_direct_serial
-
-        # AVR in "service" status should NOT be skipped (flashes directly)
-        assert not should_skip(dev_avr, "service")
-        # Katapult serial in "service" status SHOULD be skipped (needs bootloader)
-        assert should_skip(dev_katapult, "service")
-        # Linux is never skipped
-        assert not should_skip(dev_linux, "service")
+        # Direct-flash serial in "service" IS flashable (service is its ready state)
+        assert is_flashable_now("service", dev_avr) is True
+        # Katapult serial in "service" is NOT flashable yet (needs bootloader)
+        assert is_flashable_now("service", dev_katapult) is False
+        # Katapult serial in "ready" IS flashable
+        assert is_flashable_now("ready", dev_katapult) is True
 
     def test_is_katapult_defaults_true(self):
         """Devices without explicit is_katapult should default to True (backward compatibility)."""
@@ -726,6 +717,171 @@ class TestMakeFlash:
         assert dev_no_flag.get('is_katapult', True) is True
         assert dev_true.get('is_katapult', True) is True
         assert dev_false.get('is_katapult', True) is False
+
+
+# ---------------------------------------------------------------------------
+# Flash protocol (how) vs readiness (whether) — issue #25
+# ---------------------------------------------------------------------------
+
+
+class TestFlashProtocolAndReadiness:
+    """The state model split: resolve_flash_protocol() is the static 'how',
+    is_flashable_now() is the dynamic 'whether'. They must stay independent so
+    'service' means the same thing for every board type."""
+
+    # --- resolve_flash_protocol: the static "how" axis ---
+
+    def test_protocol_linux(self):
+        from backend.main import resolve_flash_protocol
+        assert resolve_flash_protocol({"method": "linux"}) == "linux"
+
+    def test_protocol_dfu(self):
+        from backend.main import resolve_flash_protocol
+        assert resolve_flash_protocol({"method": "dfu"}) == "dfu"
+
+    def test_protocol_can_is_katapult(self):
+        from backend.main import resolve_flash_protocol
+        assert resolve_flash_protocol({"method": "can"}) == "katapult"
+
+    def test_protocol_serial_katapult_by_default(self):
+        from backend.main import resolve_flash_protocol
+        # No flag, no profile → assume Katapult (backward compatible)
+        assert resolve_flash_protocol({"method": "serial"}) == "katapult"
+
+    def test_protocol_serial_direct_via_flag(self):
+        from backend.main import resolve_flash_protocol
+        assert resolve_flash_protocol(
+            {"method": "serial", "is_katapult": False}
+        ) == "direct"
+
+    def test_protocol_bridge_is_always_katapult(self):
+        from backend.main import resolve_flash_protocol
+        # A bridge reaches Katapult over serial even if is_katapult is unset
+        assert resolve_flash_protocol(
+            {"method": "serial", "is_bridge": True}
+        ) == "katapult"
+
+    def test_protocol_serial_direct_inferred_from_sam_profile(self, tmp_path):
+        """A SAM4 profile (DaVinci's board) infers direct-flash without the flag."""
+        (tmp_path / "sam4e8e.config").write_text("CONFIG_MACH_SAM=y\nCONFIG_MCU=sam4e8e\n")
+        with patch("backend.main.PROFILES_DIR", str(tmp_path)):
+            from backend.main import resolve_flash_protocol
+            assert resolve_flash_protocol(
+                {"method": "serial", "profile": "sam4e8e"}
+            ) == "direct"
+
+    def test_protocol_serial_direct_inferred_from_avr_profile(self, tmp_path):
+        (tmp_path / "mega.config").write_text("CONFIG_MACH_AVR=y\n")
+        with patch("backend.main.PROFILES_DIR", str(tmp_path)):
+            from backend.main import resolve_flash_protocol
+            assert resolve_flash_protocol(
+                {"method": "serial", "profile": "mega"}
+            ) == "direct"
+
+    def test_protocol_stm32_profile_stays_katapult(self, tmp_path):
+        (tmp_path / "spider.config").write_text("CONFIG_MACH_STM32=y\n")
+        with patch("backend.main.PROFILES_DIR", str(tmp_path)):
+            from backend.main import resolve_flash_protocol
+            assert resolve_flash_protocol(
+                {"method": "serial", "profile": "spider"}
+            ) == "katapult"
+
+    # --- is_flashable_now: the dynamic "whether" axis, full matrix ---
+
+    def test_flashable_matrix(self):
+        from backend.main import is_flashable_now
+
+        direct = {"method": "serial", "is_katapult": False}
+        katapult = {"method": "serial", "is_katapult": True}
+        can = {"method": "can"}
+
+        # bootloader modes are always flashable, regardless of protocol
+        assert is_flashable_now("ready", katapult) is True
+        assert is_flashable_now("ready", can) is True
+        assert is_flashable_now("dfu", katapult) is True
+
+        # 'service' is flashable ONLY for direct-flash devices
+        assert is_flashable_now("service", direct) is True
+        assert is_flashable_now("service", katapult) is False
+        assert is_flashable_now("service", can) is False
+
+        # offline is never flashable
+        assert is_flashable_now("offline", direct) is False
+        assert is_flashable_now("offline", katapult) is False
+
+    def test_flashes_directly_matches_protocol(self):
+        from backend.main import flashes_directly
+        assert flashes_directly({"method": "serial", "is_katapult": False}) is True
+        assert flashes_directly({"method": "serial", "is_katapult": True}) is False
+        assert flashes_directly({"method": "can"}) is False
+        assert flashes_directly({"method": "linux"}) is False
+
+    def test_skip_reason(self):
+        from backend.main import skip_reason
+
+        katapult = {"method": "can", "is_katapult": True}
+        direct = {"method": "serial", "is_katapult": False}
+
+        # Offline is unreachable regardless of protocol
+        assert skip_reason("offline", katapult) == "offline / unreachable"
+        # Katapult in service needs a reboot (Flash All)
+        assert "Flash All" in skip_reason("service", katapult)
+        # Direct-flash in service is not given the reboot reason (it flashes)
+        assert skip_reason("service", direct) == "service"
+
+    def test_flash_ready_does_not_reboot_but_flash_all_does(self):
+        """Flash Ready must not reboot running MCUs; Flash All may."""
+        from backend.main import reboots_into_bootloader
+
+        katapult_can = {"method": "can", "is_katapult": True, "is_bridge": False}
+        direct = {"method": "serial", "is_katapult": False}
+        bridge = {"method": "can", "is_katapult": True, "is_bridge": True}
+
+        # Flash Ready never reboots
+        assert reboots_into_bootloader("build-flash-ready", katapult_can) is False
+        # Flash All reboots a Katapult device into the bootloader
+        assert reboots_into_bootloader("build-flash-all", katapult_can) is True
+        # Direct-flash boards flash in place — never rebooted, even on Flash All
+        assert reboots_into_bootloader("build-flash-all", direct) is False
+        # Bridges are handled in a later phase, not here
+        assert reboots_into_bootloader("build-flash-all", bridge) is False
+
+    def test_flashed_by_ready_predicts_build_need(self):
+        """Build phase must build for devices Flash Ready will flash."""
+        from backend.main import flashed_by_ready
+
+        # Linux host always flashes (it becomes ready once services stop)
+        assert flashed_by_ready("service", {"method": "linux"}) is True
+        # Direct-flash board in service flashes in place
+        assert flashed_by_ready(
+            "service", {"method": "serial", "is_katapult": False}
+        ) is True
+        # Katapult device in service won't flash (needs reboot) -> no build
+        assert flashed_by_ready(
+            "service", {"method": "can", "is_katapult": True}
+        ) is False
+        # Offline device won't flash -> no build
+        assert flashed_by_ready(
+            "offline", {"method": "can", "is_katapult": True}
+        ) is False
+        # A device already in a bootloader flashes
+        assert flashed_by_ready(
+            "ready", {"method": "can", "is_katapult": True}
+        ) is True
+
+    def test_reconcile_flash_status(self):
+        """A device present at discovery must not be downgraded to offline just
+        because services were stopped and it's momentarily undetectable."""
+        from backend.main import reconcile_flash_status
+
+        # Re-check 'offline' but it was 'service' at discovery -> keep 'service'
+        assert reconcile_flash_status("offline", "service") == "service"
+        # Re-check 'offline' and it really was offline at discovery -> offline
+        assert reconcile_flash_status("offline", "offline") == "offline"
+        # No discovery status to fall back on -> trust the re-check
+        assert reconcile_flash_status("offline", None) == "offline"
+        # A successful transition (e.g. service -> ready after reboot) is kept
+        assert reconcile_flash_status("ready", "service") == "ready"
 
 
 # ---------------------------------------------------------------------------

--- a/ui/index.html
+++ b/ui/index.html
@@ -71,7 +71,7 @@
                     Using system kconfiglib. Please click Update to switch to {{ firmwareName }}'s version for full compatibility.
                 </div>
                 <div class="flex items-center text-[10px] text-gray-500">
-                    <span>v1.3.2-alpha</span>
+                    <span>v1.4.0-alpha</span>
                     <span v-if="currentBranch && currentBranch !== 'main'" class="ml-1 text-yellow-500">({{ currentBranch }})</span>
                     <span v-if="currentCommit" class="ml-auto text-gray-600">{{ currentCommit }}</span>
                 </div>

--- a/ui/index.html
+++ b/ui/index.html
@@ -101,16 +101,16 @@
                     </span>
                 </div>
                 <div v-if="view === 'dashboard'" class="flex items-center space-x-1.5 md:space-x-2 mt-1.5 md:mt-0 overflow-x-auto pb-1 md:pb-0 -mx-1 px-1">
-                    <button @click="runBatch('build-all')" :disabled="building || flashing" class="bg-gray-700 hover:bg-gray-600 text-white px-2 md:px-3 py-1 rounded text-[9px] md:text-[10px] font-bold disabled:opacity-50 uppercase whitespace-nowrap flex-none">
+                    <button @click="runBatch('build-all')" :disabled="building || flashing" title="Compile firmware for every fleet device. Does not flash anything." class="bg-gray-700 hover:bg-gray-600 text-white px-2 md:px-3 py-1 rounded text-[9px] md:text-[10px] font-bold disabled:opacity-50 uppercase whitespace-nowrap flex-none">
                         Build All
                     </button>
-                    <button @click="runBatch('flash-all')" :disabled="building || flashing || printing" class="bg-gray-700 hover:bg-gray-600 text-white px-2 md:px-3 py-1 rounded text-[9px] md:text-[10px] font-bold disabled:opacity-50 uppercase whitespace-nowrap flex-none">
+                    <button @click="runBatch('flash-all')" :disabled="building || flashing || printing" title="Reboot every reachable device into its bootloader and flash it (uses existing firmware; does not build first)." class="bg-gray-700 hover:bg-gray-600 text-white px-2 md:px-3 py-1 rounded text-[9px] md:text-[10px] font-bold disabled:opacity-50 uppercase whitespace-nowrap flex-none">
                         Flash All
                     </button>
-                    <button @click="runBatch('build-flash-ready')" :disabled="building || flashing || printing" class="bg-orange-600 hover:bg-orange-700 text-white px-2 md:px-3 py-1 rounded text-[9px] md:text-[10px] font-bold disabled:opacity-50 uppercase whitespace-nowrap flex-none">
-                        Build & Flash Ready
+                    <button @click="runBatch('build-flash-ready')" :disabled="building || flashing || printing" title="Build, then flash only devices that can update without a reboot: boards already in a bootloader (Katapult/DFU), direct-flash USB/serial boards, and the host MCU. Running Katapult/CAN MCUs are left alone (use Build & Flash All for those)." class="bg-orange-600 hover:bg-orange-700 text-white px-2 md:px-3 py-1 rounded text-[9px] md:text-[10px] font-bold disabled:opacity-50 uppercase whitespace-nowrap flex-none">
+                        Build & Flash (No Reboot)
                     </button>
-                    <button @click="runBatch('build-flash-all')" :disabled="building || flashing || printing" class="bg-red-700 hover:bg-red-800 text-white px-2 md:px-3 py-1 rounded text-[9px] md:text-[10px] font-bold disabled:opacity-50 uppercase whitespace-nowrap flex-none">
+                    <button @click="runBatch('build-flash-all')" :disabled="building || flashing || printing" title="Build, then reboot every reachable device into its bootloader and flash all of them." class="bg-red-700 hover:bg-red-800 text-white px-2 md:px-3 py-1 rounded text-[9px] md:text-[10px] font-bold disabled:opacity-50 uppercase whitespace-nowrap flex-none">
                         Build & Flash All
                     </button>
                 </div>

--- a/ui/index.html
+++ b/ui/index.html
@@ -235,6 +235,7 @@
                                     <option value="full">Fit Browser</option>
                                 </select>
                                 <button v-if="currentTaskId" @click="cancelTask" class="text-red-500 hover:text-red-400 font-bold">Cancel</button>
+                                <button @click="copyLogs" :class="logsCopied ? 'text-green-400' : 'text-gray-500 hover:text-white'" title="Copy logs as Markdown for GitHub">{{ logsCopied ? 'Copied!' : 'Copy' }}</button>
                                 <button @click="buildLogs = ''" class="text-gray-500 hover:text-white">Clear</button>
                             </div>
                         </div>
@@ -932,7 +933,7 @@
                             return `<span class="text-yellow-400">${line}</span>`;
                         }
                         // Section headers (cyan/blue)
-                        if (line.includes('=====') || line.includes('[SUMMARY]') || line.includes('BUILD RESULTS') || line.includes('FLASH RESULTS')) {
+                        if (line.includes('=====') || line.includes('[SUMMARY]') || line.includes('BUILD RESULTS') || line.includes('FLASH RESULTS') || line.includes('[PROTOCOL, STATUS]')) {
                             return `<span class="text-cyan-400">${line}</span>`;
                         }
                         // Phase markers (blue) - ">>> BATCH" or "<<< BATCH" 
@@ -1475,6 +1476,45 @@
                         buildLogs.value += `>>> Cancellation requested...\n`;
                     } catch (e) {
                         buildLogs.value += `!!! Failed to cancel: ${e.message}\n`;
+                    }
+                };
+
+                const logsCopied = ref(false);
+                const copyLogs = async () => {
+                    // Clean internal color markers and wrap as a GitHub-ready
+                    // fenced code block so it pastes neatly into issues/PRs.
+                    const clean = buildLogs.value
+                        .replace(/\[COLOR:[A-Z]+\]/g, '')
+                        .replace(/\[\/COLOR\]/g, '')
+                        .replace(/[ \t]+$/gm, '')
+                        .replace(/\s+$/, '');
+                    if (!clean) return;
+                    const md = '```\n' + clean + '\n```';
+                    let ok = false;
+                    try {
+                        if (navigator.clipboard && window.isSecureContext) {
+                            await navigator.clipboard.writeText(md);
+                            ok = true;
+                        }
+                    } catch (e) { /* fall back to execCommand below */ }
+                    if (!ok) {
+                        // http:// (non-secure) contexts block the async clipboard API,
+                        // which is how KlipperFleet is normally served — use a hidden
+                        // textarea + execCommand as a fallback.
+                        const ta = document.createElement('textarea');
+                        ta.value = md;
+                        ta.style.position = 'fixed';
+                        ta.style.top = '-1000px';
+                        ta.style.opacity = '0';
+                        document.body.appendChild(ta);
+                        ta.focus();
+                        ta.select();
+                        try { ok = document.execCommand('copy'); } catch (e) { ok = false; }
+                        document.body.removeChild(ta);
+                    }
+                    if (ok) {
+                        logsCopied.value = true;
+                        setTimeout(() => { logsCopied.value = false; }, 1500);
                     }
                 };
 
@@ -2145,7 +2185,7 @@
 
                 return { 
                     view, sidebarOpen, configTree, profiles, fleet, selectedProfile, loading, building, flashing, updating, querying, printing, printState, printFilename,
-                    buildLogs, formattedLogs, expandLogs, expandLogsHeight, updateValue, saveProfile, saveProfileAs, newProfile, deleteProfile, renameProfile, loadProfile, createMissingProfile, startBuild, runBatch, selfUpdate,
+                    buildLogs, formattedLogs, expandLogs, expandLogsHeight, copyLogs, logsCopied, updateValue, saveProfile, saveProfileAs, newProfile, deleteProfile, renameProfile, loadProfile, createMissingProfile, startBuild, runBatch, selfUpdate,
                     devices, selectedDevice, discoverDevices, startFlash, quickFlash, quickBuild, quickFlashOnly, flashBeacon, beaconUpToDate, buildAndDownload, rebootDevice, statusColor, formatStatus,
                     addDeviceToFleet, attachToFleet, updateFleetDevice, onDeviceProfileChange, removeDeviceFromFleet, error, modifiedValues, formatNotes,
                     printerUrl, printerTitle, hasReferrer, profileInfo, isProfileCanBridge, isProfileLinux,


### PR DESCRIPTION
Separate a device's flash *protocol* (how it receives firmware) from its *readiness* (whether it can be flashed right now), so a device's reported state means the same thing for every board type.

Issue #25: Flash Ready skipped direct-flash serial MCUs (AVR/SAM and other non-Katapult boards) and devices sitting in DFU. They never report the 'ready' bootloader state  for a direct-flash board, 'service' *is* its flashable state so the old `status == 'ready'` gate excluded them forever.

Core state model:
- resolve_flash_protocol(): the static "how"  direct / katapult / dfu / linux / beacon, inferred from method + profile (CONFIG_MACH_AVR / CONFIG_MACH_SAM) so older fleet entries classify correctly.
- is_flashable_now(): the dynamic "whether" ready/dfu always, plus direct-flash boards in service. The single gate for Flash Ready.
- flashes_directly() replaces the is_direct_serial special-casing that was duplicated across the batch and single-flash paths.

Flash Ready behavior:
- No longer reboots running Katapult MCUs. reboots_into_bootloader() gates the bootloader reboot to Flash All; Flash Ready only flashes what is already flashable and skips the rest.
- reconcile_flash_status(): a running MCU that becomes undetectable once services are stopped (a Klipper-mode CAN node not in Katapult) is no longer mislabeled 'offline'; its discovery status is trusted instead.
- Build phase for Flash Ready (flashed_by_ready) only compiles firmware for devices that will actually be flashed, skipping offline / service-Katapult / excluded devices. Flash All and plain Build still build everything.

Summary + UI:
- skip_reason(): human-readable skip reasons (offline / needs reboot).
- Redesigned FLASH RESULTS as an aligned table: DEVICE / [PROTOCOL, STATUS] / RESULT / SKIP REASON, with a cyan header matching the other section headers.
- Copy button on the log pane copies the terminal as a GitHub-ready fenced code block, with an execCommand fallback for http (non-secure) contexts.

Tests: added coverage for resolve_flash_protocol, is_flashable_now, flashes_directly, skip_reason, reboots_into_bootloader, reconcile_flash_status, and flashed_by_ready.

B&FA:
<img width="635" height="355" alt="image" src="https://github.com/user-attachments/assets/7d7fbf1e-bb18-48b9-9916-ff809bd30762" />

B&FR:
<img width="735" height="506" alt="image" src="https://github.com/user-attachments/assets/9cff011d-2279-47ef-995a-d9121ee48314" />


@ModularPrintingSystem please test and report back.