### PR TITLE
feat(flash): enter DFU via Katapult flashtool --request-dfu

### DIFF
--- a/backend/flash_manager.py
+++ b/backend/flash_manager.py
@@ -1386,10 +1386,62 @@ class FlashManager:
         else:
             yield '>>> Device path not found. It may already be in bootloader mode.\n'
 
-    async def reboot_to_dfu(self, device_id: str) -> AsyncGenerator[str, None]:
-        """Attempts to reboot a device into DFU mode using the 1200bps magic baud rate."""
+    async def reboot_to_dfu(
+        self,
+        device_id: str,
+        use_katapult_dfu: bool = False,
+        interface: str = 'can0',
+    ) -> AsyncGenerator[str, None]:
+        """Attempts to reboot a device into DFU mode.
+
+        When ``use_katapult_dfu`` is set, Katapult's ``flashtool.py
+        --request-dfu`` is used to ask the bootloader to jump into the
+        STM32 ROM DFU bootloader (requires Katapult built with DFU
+        support). flashtool handles the full chain itself: a device
+        running Klipper is first rebooted into Katapult (serial or CAN
+        bridge), then asked to enter DFU. Falls back to the 1200bps
+        magic baud trick on failure.
+        """
         # If device_id is a DFU ID, but the device is in Serial mode, resolve it first
         actual_id: str = await self.resolve_serial_id(device_id)
+        if use_katapult_dfu:
+            yield f'>>> Requesting ROM DFU reboot for {actual_id} via Katapult (--request-dfu)...\n'
+            cmd: List[str] = [
+                'python3',
+                os.path.join(self.katapult_dir, 'scripts', 'flashtool.py'),
+            ]
+            is_can: bool = not actual_id.startswith('/dev/')
+            if is_can:
+                cmd += ['-i', interface, '-u', actual_id]
+            else:
+                cmd += ['-d', actual_id]
+            cmd.append('--request-dfu')
+            if is_can:
+                async with self._can_lock:
+                    process: Process = await asyncio.create_subprocess_exec(
+                        *cmd,
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.STDOUT,
+                    )
+                    stdout, _ = await process.communicate()
+                    self._can_cache_time[interface] = 0.0  # Invalidate cache
+            else:
+                process = await asyncio.create_subprocess_exec(
+                    *cmd,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.STDOUT,
+                )
+                stdout, _ = await process.communicate()
+            yield stdout.decode()
+            if process.returncode == 0:
+                yield '>>> DFU request sent. Waiting 3s for USB enumeration...\n'
+                await asyncio.sleep(3)
+                return
+            yield (
+                '>>> Katapult DFU request failed (flashtool or the Katapult '
+                'build may lack --request-dfu support). Falling back to the '
+                '1200bps trick.\n'
+            )
         yield f'>>> Attempting to reboot {actual_id} into DFU mode (1200bps trick)...\n'
         try:
             # The 1200bps trick: open and close the port at 1200bps

--- a/backend/main.py
+++ b/backend/main.py
@@ -685,6 +685,7 @@ class Device(BaseModel):
     dfu_id: Optional[str] = None
     magic_baud_tested: bool = False
     use_magic_baud: bool = False
+    use_katapult_dfu: bool = False
     dfu_exit_tested: bool = False
     use_dfu_exit: bool = False
     exclude_from_batch: bool = False
@@ -698,6 +699,7 @@ class FlashRequest(BaseModel):
     dfu_id: Optional[str] = None
     baudrate: Optional[int] = 250000  # Serial baudrate for Katapult
     use_magic_baud: Optional[bool] = False
+    use_katapult_dfu: Optional[bool] = False
     use_dfu_exit: Optional[bool] = True
 
 
@@ -1438,6 +1440,9 @@ async def batch_operation(
                                     'use_magic_baud': dev.get(
                                         'use_magic_baud', False
                                     ),
+                                    'use_katapult_dfu': dev.get(
+                                        'use_katapult_dfu', False
+                                    ),
                                     'interface': dev.get('interface', 'can0'),
                                     'baudrate': dev.get('baudrate', 250000),
                                     'dfu_id': dev.get('dfu_id'),
@@ -1468,13 +1473,21 @@ async def batch_operation(
                         if task_store.is_cancelled(task_id):
                             return
                         if dev_info['method'] == 'dfu':
-                            if dev_info.get('use_magic_baud'):
+                            if dev_info.get('use_magic_baud') or dev_info.get(
+                                'use_katapult_dfu'
+                            ):
                                 task_store.add_log(
                                     task_id,
                                     f'>>> Requesting DFU reboot for {dev_info["name"]} ({dev_info["id"]})...\n',
                                 )
                                 async for log in flash_mgr.reboot_to_dfu(
-                                    dev_info['id']
+                                    dev_info['id'],
+                                    use_katapult_dfu=dev_info.get(
+                                        'use_katapult_dfu', False
+                                    ),
+                                    interface=dev_info.get(
+                                        'interface', 'can0'
+                                    ),
                                 ):
                                     if task_store.is_cancelled(task_id):
                                         return
@@ -1707,7 +1720,11 @@ async def batch_operation(
                                     await flash_mgr.resolve_serial_id(dev['id'])
                                 )
                                 async for log in flash_mgr.reboot_to_dfu(
-                                    serial_id
+                                    serial_id,
+                                    use_katapult_dfu=dev.get(
+                                        'use_katapult_dfu', False
+                                    ),
+                                    interface=dev.get('interface', 'can0'),
                                 ):
                                     if task_store.is_cancelled(task_id):
                                         return
@@ -2561,9 +2578,12 @@ async def flash_device(req: FlashRequest) -> StreamingResponse:
                 elif req.method == 'dfu' or (
                     req.method == 'serial' and req.dfu_id
                 ):
-                    if req.use_magic_baud:
-                        yield f'>>> Rebooting {req.device_id} to DFU mode (Magic Baud)...\n'
-                        async for log in flash_mgr.reboot_to_dfu(req.device_id):
+                    if req.use_magic_baud or req.use_katapult_dfu:
+                        yield f'>>> Rebooting {req.device_id} to DFU mode...\n'
+                        async for log in flash_mgr.reboot_to_dfu(
+                            req.device_id,
+                            use_katapult_dfu=bool(req.use_katapult_dfu),
+                        ):
                             if task_store.is_cancelled(task_id):
                                 return
                             yield log

--- a/tests/test_flash_manager.py
+++ b/tests/test_flash_manager.py
@@ -600,3 +600,112 @@ class TestPostFlashRescan:
         ]
         # Old path still present — nothing changed
         assert old_device_id in current_ids
+
+
+class TestKatapultDfuRequest:
+    """reboot_to_dfu() with use_katapult_dfu uses flashtool --request-dfu.
+
+    Katapult devices do not implement the 1200bps magic baud protocol, so
+    boards without accessible BOOT0/RESET buttons need Katapult's DFU
+    command (flashtool.py --request-dfu) to enter the ROM DFU bootloader.
+    """
+
+    def _mock_process(self, returncode, output=b""):
+        proc = MagicMock()
+        proc.communicate = AsyncMock(return_value=(output, None))
+        proc.returncode = returncode
+        return proc
+
+    def test_serial_path_uses_flashtool_request_dfu(self):
+        """A /dev/ path must invoke flashtool -d <path> --request-dfu."""
+        fm = FlashManager("/tmp/klipper", "/tmp/katapult")
+        serial_path = "/dev/serial/by-id/usb-katapult_stm32f446xx_ABC123-if00"
+        fm.resolve_serial_id = AsyncMock(return_value=serial_path)
+        captured = {}
+
+        async def fake_exec(*cmd, **kwargs):
+            captured["cmd"] = list(cmd)
+            return self._mock_process(0, b"DFU Request Complete\n")
+
+        async def run():
+            lines = []
+            with patch("asyncio.create_subprocess_exec", side_effect=fake_exec), \
+                 patch("asyncio.sleep", new=AsyncMock()):
+                async for line in fm.reboot_to_dfu(
+                    serial_path, use_katapult_dfu=True
+                ):
+                    lines.append(line)
+            assert "--request-dfu" in captured["cmd"]
+            assert "-d" in captured["cmd"]
+            assert serial_path in captured["cmd"]
+            # Success: the 1200bps fallback must not run
+            assert not any("1200bps trick" in line for line in lines)
+
+        asyncio.get_event_loop().run_until_complete(run())
+
+    def test_can_uuid_uses_interface_and_uuid(self):
+        """A CAN UUID must invoke flashtool -i <interface> -u <uuid> --request-dfu."""
+        fm = FlashManager("/tmp/klipper", "/tmp/katapult")
+        can_uuid = "c20262880b1b"
+        fm.resolve_serial_id = AsyncMock(return_value=can_uuid)
+        captured = {}
+
+        async def fake_exec(*cmd, **kwargs):
+            captured["cmd"] = list(cmd)
+            return self._mock_process(0, b"DFU Request Complete\n")
+
+        async def run():
+            with patch("asyncio.create_subprocess_exec", side_effect=fake_exec), \
+                 patch("asyncio.sleep", new=AsyncMock()):
+                async for _ in fm.reboot_to_dfu(
+                    can_uuid, use_katapult_dfu=True, interface="can0"
+                ):
+                    pass
+            assert "--request-dfu" in captured["cmd"]
+            assert "-u" in captured["cmd"]
+            assert can_uuid in captured["cmd"]
+            assert "-i" in captured["cmd"]
+
+        asyncio.get_event_loop().run_until_complete(run())
+
+    def test_falls_back_to_magic_baud_on_failure(self):
+        """A failed flashtool DFU request must fall back to the 1200bps trick."""
+        fm = FlashManager("/tmp/klipper", "/tmp/katapult")
+        serial_path = "/dev/serial/by-id/usb-katapult_stm32f446xx_ABC123-if00"
+        fm.resolve_serial_id = AsyncMock(return_value=serial_path)
+
+        async def fake_exec(*cmd, **kwargs):
+            return self._mock_process(1, b"Flash Tool Error\n")
+
+        async def run():
+            lines = []
+            with patch("asyncio.create_subprocess_exec", side_effect=fake_exec), \
+                 patch("asyncio.sleep", new=AsyncMock()):
+                async for line in fm.reboot_to_dfu(
+                    serial_path, use_katapult_dfu=True
+                ):
+                    lines.append(line)
+            assert any("Falling back" in line for line in lines)
+            assert any("1200bps trick" in line for line in lines)
+
+        asyncio.get_event_loop().run_until_complete(run())
+
+    def test_disabled_by_default(self):
+        """Without use_katapult_dfu, flashtool must not be invoked."""
+        fm = FlashManager("/tmp/klipper", "/tmp/katapult")
+        serial_path = "/dev/serial/by-id/usb-katapult_stm32f446xx_ABC123-if00"
+        fm.resolve_serial_id = AsyncMock(return_value=serial_path)
+        captured = {}
+
+        async def fake_exec(*cmd, **kwargs):
+            captured["cmd"] = list(cmd)
+            return self._mock_process(0)
+
+        async def run():
+            with patch("asyncio.create_subprocess_exec", side_effect=fake_exec), \
+                 patch("asyncio.sleep", new=AsyncMock()):
+                async for _ in fm.reboot_to_dfu(serial_path):
+                    pass
+            assert "cmd" not in captured
+
+        asyncio.get_event_loop().run_until_complete(run())

--- a/ui/index.html
+++ b/ui/index.html
@@ -605,9 +605,17 @@
                                                 <span class="text-[9px] text-gray-400 group-hover:text-gray-200 uppercase font-bold" title="AUTO-DFU: If the device is in runtime, attempt to reboot it into DFU before flashing.">Auto-DFU</span>
                                             </label>
 
+                                            <label class="flex items-center space-x-1.5 cursor-pointer group" v-if="dev.is_katapult">
+                                                <input type="checkbox"
+                                                       v-model="dev.use_katapult_dfu"
+                                                       @change="updateFleetDevice(dev)"
+                                                       class="h-3 w-3 rounded border-gray-700 bg-gray-900 text-orange-600 focus:ring-orange-500 disabled:cursor-not-allowed">
+                                                <span class="text-[9px] text-gray-400 group-hover:text-gray-200 uppercase font-bold" title="KATAPULT-DFU: Enter DFU via Katapult's flashtool --request-dfu (requires Katapult built with DFU support).">Katapult-DFU</span>
+                                            </label>
+
                                             <label class="flex items-center space-x-1.5 cursor-pointer group" :class="{'opacity-40 cursor-not-allowed': !dev.dfu_exit_tested}">
-                                                <input type="checkbox" 
-                                                       v-model="dev.use_dfu_exit" 
+                                                <input type="checkbox"
+                                                       v-model="dev.use_dfu_exit"
                                                        :disabled="!dev.dfu_exit_tested"
                                                        @change="updateFleetDevice(dev)"
                                                        class="h-3 w-3 rounded border-gray-700 bg-gray-900 text-orange-600 focus:ring-orange-500 disabled:cursor-not-allowed">
@@ -1556,6 +1564,7 @@
                     // Find the device in fleet to get use_magic_baud setting
                     const dev = fleet.value.find(d => d.id === deviceId);
                     const useMagicBaud = dev ? dev.use_magic_baud : false;
+                    const useKatapultDfu = dev ? dev.use_katapult_dfu : false;
 
                     taskCancelled.value = false;
                     flashing.value = true;
@@ -1570,7 +1579,8 @@
                                 device_id: deviceId, 
                                 method, 
                                 dfu_id: dfuId,
-                                use_magic_baud: useMagicBaud
+                                use_magic_baud: useMagicBaud,
+                                use_katapult_dfu: useKatapultDfu
                             })
                         });
 
@@ -1790,6 +1800,7 @@
                         dfu_id: method === 'dfu' ? dev.id : null,
                         magic_baud_tested: false,
                         use_magic_baud: false,
+                        use_katapult_dfu: false,
                         exclude_from_batch: isBeacon,  // beacon uses update_firmware.py, not batch pipeline; always excluded
                         custom_make_command: null
                     };


### PR DESCRIPTION
This is a very self-serving but hopefullly altruistic PR. I have a Spider v3.0 stm32F446 board that requires turning the printer over to do the press boot-reset-boot dance. I got the digital twin to create a PR in katapult to fix the software dfu-mode.

This PR adds the ability to use the new switch to place the board into dfu-mode for the flashing to succeed. Below the twins description of the problem and fix.

## Problem

Katapult devices do not implement the 1200bps magic-baud protocol, so the existing Auto-DFU path (`use_magic_baud`) can never reboot them into ROM DFU. Boards with broken or inaccessible BOOT0/RESET buttons — e.g. a Fysetc Spider v3.0 running Klipper in USB-to-CAN bridge mode — are stuck with "MANUAL DFU ENTRY REQUIRED" during flash, which is impossible without buttons.

## What

Katapult (with DFU support built in — see companion PR to [Arksine/katapult ](https://github.com/Arksine/katapult/pull/185) adding `flashtool.py --request-dfu`) can now ask the bootloader to jump into the STM32 ROM DFU bootloader from software. This PR plumbs that through KlipperFleet:

- New per-device flag `use_katapult_dfu` (Device model, FlashRequest, fleet.json), following the existing `use_magic_baud` / `use_dfu_exit` idiom.
- `FlashManager.reboot_to_dfu()` gains `use_katapult_dfu` / `interface` parameters: when set, it invokes `flashtool.py --request-dfu` (serial `-d <path>` or CAN `-i <interface> -u <uuid>`, holding the CAN lock for the latter). flashtool handles the full chain itself — a device running Klipper is first rebooted into Katapult (serial or CAN bridge), then asked to enter DFU. On failure (older flashtool or a Katapult build without DFU support) it falls back to the existing 1200bps trick, so behavior is unchanged for current setups.
- All three `reboot_to_dfu` call sites (batch flow, bridge flow, single-flash endpoint) pass the flag.
- UI: a "Katapult-DFU" checkbox, shown for Katapult devices, persisted via `updateFleetDevice` and sent with flash requests.

## Testing

- 4 new tests in `tests/test_flash_manager.py` (`TestKatapultDfuRequest`): serial command shape, CAN command shape, fallback on failure, disabled-by-default.
- Full suite: 185 passed.
- Verified live on a Fysetc Spider v3.0 (STM32F446, USB-to-CAN bridge): Klipper → Katapult → ROM DFU (`0483:df11`) → dfu-util flash → back to Klipper, no physical button presses.
